### PR TITLE
Increase the Vagrant version to allow 2.0.3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
-Vagrant.require_version ">= 1.8.5", "<= 2.0.1"
+Vagrant.require_version ">= 1.8.5", "<= 2.0.3"
 
 $cpus   = ENV.fetch("ISLANDORA_VAGRANT_CPUS", "1")
 $memory = ENV.fetch("ISLANDORA_VAGRANT_MEMORY", "3072")


### PR DESCRIPTION
Islandora-vagrant forced 2.0.3 for so we should update too.